### PR TITLE
🐛 Set stdin/stdout as default file for template/output

### DIFF
--- a/internal/opt.go
+++ b/internal/opt.go
@@ -15,10 +15,14 @@ type Options struct {
 }
 
 func NewOptions(args []string) (opts Options, err error) {
+	opts.Template = os.Stdin
+	opts.Output = os.Stdout
+
 	parser := argparse.NewParser(
 		"gotempl", "Generic templating tool",
 		&argparse.ParserConfig{
-			AddShellCompletion: true,
+			AddShellCompletion:     true,
+			DisableDefaultShowHelp: true,
 		},
 	)
 
@@ -29,11 +33,7 @@ func NewOptions(args []string) (opts Options, err error) {
 			Required:   false,
 			Help:       "Path to Go Template file. Default is stdin. Example: \"TEST env var is {{ .Env.TEST }} and TEST data value is {{ .Data.TEST }}.\"",
 			Validate: func(arg string) (err error) {
-				if arg == "" {
-					opts.Template = os.Stdin
-				} else {
-					opts.Template, err = os.Open(arg)
-				}
+				opts.Template, err = os.Open(arg)
 
 				return
 			},
@@ -46,11 +46,7 @@ func NewOptions(args []string) (opts Options, err error) {
 			Required: false,
 			Help:     "Path to output file. Default is stdout",
 			Validate: func(arg string) (err error) {
-				if arg == "" {
-					opts.Output = os.Stdout
-				} else {
-					opts.Output, err = os.Create(arg)
-				}
+				opts.Output, err = os.Create(arg)
 
 				return
 			},

--- a/main_test.go
+++ b/main_test.go
@@ -48,8 +48,8 @@ func Test(t *testing.T) {
 	dataParser, template, expected := NewTestData(template, expected)
 	opts.DataParser = dataParser
 
-	const templatePath = "/tmp/gotempl.test"
-	templateFile, err := os.Create(templatePath)
+	const templatePath = "gotempl.test"
+	templateFile, err := os.CreateTemp("tests", templatePath)
 
 	if err != nil {
 		t.Fatal(err)
@@ -71,7 +71,7 @@ func Test(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = os.Remove(templatePath)
+	err = os.Remove(templateFile.Name())
 
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This PR aims to setup stdin/stdout to template/output argument when avoided.

# Actual Behavior

STDIN/STDOUT ignored by default

# Desired Behavior

STDIN/STDOUT used for template/output by default

# Changes
- [x] set stdin as default template
- [x] set stdout as default output
 