### PR TITLE
:sparkles: :boom: Add flag to switch from TEXT to HTML template

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Generic templating tool which use both environment variables and data files as t
 optional arguments:
   --help, -h                           show this help message
   --completion                         show command completion script
+  --html, -H                           Escape template for HTML output
   --template TEMPLATE, -t TEMPLATE     Path to Go Template file. Default is stdin.
   --output OUTPUT, -o OUTPUT           Path to output file. Default is stdout
   --data-json DATA-JSON, -j DATA-JSON  Path to JSON file

--- a/internal/io/main.go
+++ b/internal/io/main.go
@@ -1,16 +1,16 @@
 package io
 
 import (
-	"html/template"
 	"io"
 	"os"
 
 	"github.com/link-society/gotempl/internal/decoder"
 	"github.com/link-society/gotempl/internal/options"
+	"github.com/link-society/gotempl/internal/template"
 )
 
 type Context struct {
-	Template   *template.Template
+	Template   *template.GenericTemplate
 	Data       decoder.Data
 	OutputPath string
 }
@@ -35,7 +35,7 @@ func ExecuteTemplate(args []string) error {
 }
 
 func NewContext(opts options.Options) (Context, error) {
-	template, err := ReadTemplate(opts.TemplatePaths)
+	template, err := ReadTemplate(opts.TemplatePaths, opts.HTML)
 	if err != nil {
 		return Context{}, err
 	}

--- a/internal/io/utils.go
+++ b/internal/io/utils.go
@@ -4,16 +4,15 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"html/template"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 
-	"github.com/Masterminds/sprig"
+	"github.com/link-society/gotempl/internal/template"
 )
 
-func ReadTemplate(paths []string) (*template.Template, error) {
+func ReadTemplate(paths []string, html bool) (*template.GenericTemplate, error) {
 	var reader io.Reader
 
 	if len(paths) == 0 {
@@ -38,11 +37,7 @@ func ReadTemplate(paths []string) (*template.Template, error) {
 		return nil, errors.New(fmt.Sprintf("[template-read] %s", err))
 	}
 
-	template, err := template.
-		New("template").
-		Funcs(sprig.FuncMap()).
-		Funcs(Funcs).
-		Parse(string(content))
+	template, err := template.New("template", html).Parse(string(content))
 
 	if err != nil {
 		return nil, errors.New(fmt.Sprintf("[template-parse] %s", err))

--- a/internal/options/main.go
+++ b/internal/options/main.go
@@ -13,6 +13,7 @@ type Options struct {
 	TemplatePaths []string
 	TemplateData  decoder.Data
 	OutputPath    string
+	HTML          bool
 }
 
 func ParseOptions(args []string) (Options, error) {
@@ -25,6 +26,15 @@ func ParseOptions(args []string) (Options, error) {
 		&argparse.ParserConfig{
 			AddShellCompletion:     true,
 			DisableDefaultShowHelp: true,
+		},
+	)
+
+	htmlFlag := parser.Flag(
+		"H", "html",
+		&argparse.Option{
+			Positional: false,
+			Required:   false,
+			Help:       "Escape template for HTML output",
 		},
 	)
 
@@ -68,6 +78,8 @@ func ParseOptions(args []string) (Options, error) {
 			fmt.Sprintf("%v\n\n%v", err, parser.FormatHelp()),
 		)
 	}
+
+	opts.HTML = *htmlFlag
 
 	return opts, nil
 }

--- a/internal/template/funcs.go
+++ b/internal/template/funcs.go
@@ -1,4 +1,4 @@
-package io
+package template
 
 import (
 	"errors"
@@ -79,7 +79,7 @@ func ReadDir(path string) ([]string, error) {
 	return result, nil
 }
 
-var Funcs = map[string]interface{}{
+var funcs = map[string]interface{}{
 	"isDir":        IsDir,
 	"osIsDir":      IsDir,
 	"readDir":      ReadDir,

--- a/internal/template/generic.go
+++ b/internal/template/generic.go
@@ -9,8 +9,6 @@ import (
 	"github.com/Masterminds/sprig"
 )
 
-type GenericFuncMap = map[string]interface{}
-
 type GenericTemplate struct {
 	isHTML bool
 

--- a/internal/template/generic.go
+++ b/internal/template/generic.go
@@ -1,0 +1,67 @@
+package template
+
+import (
+	"io"
+
+	htemplate "html/template"
+	ttemplate "text/template"
+
+	"github.com/Masterminds/sprig"
+)
+
+type GenericFuncMap = map[string]interface{}
+
+type GenericTemplate struct {
+	isHTML bool
+
+	htmlTemplate *htemplate.Template
+	textTemplate *ttemplate.Template
+}
+
+func New(name string, html bool) *GenericTemplate {
+	if html {
+		return NewHTML(name)
+	} else {
+		return NewText(name)
+	}
+}
+
+func NewHTML(name string) *GenericTemplate {
+	return &GenericTemplate{
+		isHTML:       true,
+		htmlTemplate: htemplate.New(name).Funcs(sprig.HtmlFuncMap()).Funcs(funcs),
+		textTemplate: nil,
+	}
+}
+
+func NewText(name string) *GenericTemplate {
+	return &GenericTemplate{
+		isHTML:       false,
+		htmlTemplate: nil,
+		textTemplate: ttemplate.New(name).Funcs(sprig.TxtFuncMap()).Funcs(funcs),
+	}
+}
+
+func (tmpl *GenericTemplate) Parse(text string) (*GenericTemplate, error) {
+	var err error
+
+	if tmpl.isHTML {
+		tmpl.htmlTemplate, err = tmpl.htmlTemplate.Parse(text)
+	} else {
+		tmpl.textTemplate, err = tmpl.textTemplate.Parse(text)
+	}
+
+	return tmpl, err
+}
+
+func (tmpl *GenericTemplate) Execute(wr io.Writer, data interface{}) error {
+	var err error
+
+	if tmpl.isHTML {
+		err = tmpl.htmlTemplate.Execute(wr, data)
+	} else {
+		err = tmpl.textTemplate.Execute(wr, data)
+	}
+
+	return err
+}

--- a/main_test.go
+++ b/main_test.go
@@ -174,7 +174,7 @@ func TestReadDir(t *testing.T) {
 	}
 
 	result := stdoutBuf.String()
-	expected := "[decoder io options]"
+	expected := "[decoder io options template]"
 	assert.Equal(t, result, expected)
 }
 


### PR DESCRIPTION
**This PR provides the following changes:**

 - [x] :sparkles: Add new internal package `template`, abstracting the builtin packages `html/template` and `text/template`
 - [x] :recycle: Refactor `io` package to use this new internal package
 - [x] :sparkles: Add `-H` / `--html` flag to switch implementation
 - [x] :boom: Make the `text` implementation the default

---

## Examples

With the text implementation, the following template:

```
$ cat <<EOF | gotempl
{{ dict "foo" "bar" | toJson }}
EOF
```

Will produce:

```
{"foo":"bar"}
```

But with the HTML implementation, the same template:

```
$ cat <<EOF | gotempl -H
{{ dict "foo" "bar" | toJson }}
EOF
```

Will produce:

```
{&#34;foo&#34;:&#34;bar&#34;}
```

This was the default behavior until now, but this is obviously unexpected. Adding a function `noescape` would only clutter the template sources.